### PR TITLE
chore(deps): add dependabot.yml for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+# Dependabot configuration for automated dependency updates
+# Documentation: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Keep npm dependencies up to date
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00' # UTC timezone (all times in dependabot.yml use UTC)
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: 'npm'
+      include: 'scope'
+    labels:
+      - 'dependencies'
+      - 'npm'
+    ignore:
+      - dependency-name: 'eslint'
+        update-types:
+          - 'version-update:semver-major'
+    groups:
+      # Group all npm production dependencies together
+      # Note: Major version updates are excluded and handled individually
+      # to allow careful review of potentially breaking changes
+      production-dependencies:
+        dependency-type: 'production'
+        update-types:
+          - 'minor'
+          - 'patch'
+      # Group all npm development dependencies together
+      # Note: Major version updates are excluded and handled individually
+      # to allow careful review of potentially breaking changes
+      development-dependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  # Keep GitHub Actions up to date
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00' # UTC timezone (all times in dependabot.yml use UTC)
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'ci'
+      include: 'scope'
+    labels:
+      - 'dependencies'
+      - 'github-actions'


### PR DESCRIPTION
Adds Dependabot configuration for **version updates** to this repo.

## Context

- Dependabot **security** updates are already enabled org-wide via the FreeForCharity code security configuration #237319.
- This PR adds **version updates** so non-security bumps (minor/patch upgrades of dependencies and GitHub Actions) also flow through Dependabot as PRs.

## What's included

- Weekly schedule (Mondays 09:00 UTC)
- Grouped minor/patch updates to reduce PR churm
- Standard FFC labels and commit-message conventions

No code changes — this only adds .github/dependabot.yml.